### PR TITLE
Fix compiling for gcc10 and above

### DIFF
--- a/rules.mak.src
+++ b/rules.mak.src
@@ -139,7 +139,7 @@ DIR_ROOT_BUILDUTIL:= $(DIR_ROOT)/buildutil
 # ------------------------------------------------------------------------------
 #
 CC		:= $(shell which gcc)
-CFLAGS	:= -O2 -w -ansi -D_POSIX_SOURCE $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_OPENJP2_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
+CFLAGS	:= -O2 -w -ansi -D_POSIX_SOURCE -fcommon $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_OPENJP2_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
 #CFLAGS	:= -g $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
 CDEFS	:=
 CCC		:= $(CC) $(CFLAGS) $(CDEFS)

--- a/rules_msys.mak.src
+++ b/rules_msys.mak.src
@@ -143,7 +143,7 @@ DIR_ROOT_BUILDUTIL:= $(DIR_ROOT)/buildutil
 # ------------------------------------------------------------------------------
 #
 CC		:= gcc
-CFLAGS		:= -O2 -w -ansi -DOPJ_STATIC -D_POSIX_SOURCE -DNO_FORK_AND_EXECL  $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_OPENJP2_FLAG) $(MSYS_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
+CFLAGS		:= -O2 -w -ansi -DOPJ_STATIC -D_POSIX_SOURCE -DNO_FORK_AND_EXECL -fcommon $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_OPENJP2_FLAG) $(MSYS_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
 CDEFS		:=
 CCC		:= $(CC) $(CFLAGS) $(CDEFS)
 LDFLAGS		:= $(ARCH_FLAG)

--- a/rules_superdome.mak.src
+++ b/rules_superdome.mak.src
@@ -137,7 +137,7 @@ DIR_ROOT_BUILDUTIL:= $(DIR_ROOT)/buildutil
 # ------------------------------------------------------------------------------
 #
 CC		:= $(shell which cc)
-CFLAGS		:= +O3 -D _POSIX_SOURCE -D TARGET_OS -b $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_OPENJPEG_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
+CFLAGS		:= +O3 -fcommon -D _POSIX_SOURCE -D TARGET_OS -b $(ENDIAN_FLAG) $(NBIS_JASPER_FLAG) $(NBIS_OPENJPEG_FLAG) $(NBIS_PNG_FLAG) $(ARCH_FLAG)
 CDEFS		:=
 CCC		:= $(CC) $(CFLAGS) $(CDEFS)
 LDFLAGS		:= $(ARCH_FLAG)


### PR DESCRIPTION
External variables need to be explicitly declared once or the project needs to apply the fcommon switch.

See https://gcc.gnu.org/gcc-10/porting_to.html.