### PR TITLE
Fix memory leak in bozorth io

### DIFF
--- a/bozorth3/src/lib/bozorth3/bz_io.c
+++ b/bozorth3/src/lib/bozorth3/bz_io.c
@@ -462,6 +462,8 @@ struct xyt_struct * bz_load( const char * xyt_file )
    if ( verbose_load )
       fprintf( errorfp, "Loaded %s\n", xyt_file );
 
+   free(xytq_s);
+
    return xyt_s;
 } 
 


### PR DESCRIPTION
I found this leak while memory profiling Bozorth in my web assembly compilation of [NBIS](https://github.com/RamAddict/NBIS-JS/commit/1cc5494418bbc767cc1d1e72c1769b689d9139bd).

It's just a simple free.